### PR TITLE
Add an exporter for the total number of API hits based on AppSignal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: ruby
-before_install:
-  - sudo apt-get install Postgresql-9.3-postgis -f
-  - psql -c 'create database pp_test' -U postgres
-  - psql -c 'CREATE EXTENSION postgis;' -U postgres -d pp_test
-  - psql -c 'CREATE EXTENSION postgis_topology;' -U postgres -d pp_test
-  - sudo ln -s /usr/lib/libgeos-`geos-config --version`.so /usr/lib/libgeos.so
-
+install:
+  - sudo apt-get install -y postgresql-9.3-postgis-2.3
 before_script:
   - RACK_ENV=test bundle exec rake db:create db:migrate
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 install:
   - sudo apt-get install -y postgresql-9.3-postgis-2.3
 before_script:
+  - RACK_ENV=test bundle install
   - RACK_ENV=test bundle exec rake db:create db:migrate
 addons:
   postgresql: 9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ before_script:
   - RACK_ENV=test bundle exec rake db:create db:migrate
 addons:
   postgresql: 9.3
+  postgis: 2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
+before_install:
+    - sudo apt-get install Postgresql-9.3-postgis -f
 before_script:
   - RACK_ENV=test bundle exec rake db:create db:migrate
 addons:
   postgresql: 9.3
-  postgis: 2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: ruby
 before_install:
-    - sudo apt-get install Postgresql-9.3-postgis -f
+  - sudo apt-get install Postgresql-9.3-postgis -f
+  - psql -c 'create database pp_test' -U postgres
+  - psql -c 'CREATE EXTENSION postgis;' -U postgres -d pp_test
+  - psql -c 'CREATE EXTENSION postgis_topology;' -U postgres -d pp_test
+  - sudo ln -s /usr/lib/libgeos-`geos-config --version`.so /usr/lib/libgeos.so
+
 before_script:
   - RACK_ENV=test bundle exec rake db:create db:migrate
 addons:

--- a/config/secrets.yml.erb
+++ b/config/secrets.yml.erb
@@ -9,6 +9,7 @@ default: &default
 
 development:
   <<: *default
+  appsignal_api_token: <%= ENV["APPSIGNAL_API_TOKEN"] %>
   mailer:
     <<: *mailer
     subject_prefix: "[Development] Protected Planet API - "

--- a/lib/tasks/export_total_hits.rake
+++ b/lib/tasks/export_total_hits.rake
@@ -1,0 +1,34 @@
+require 'uri'
+require 'net/http'
+
+namespace :export do
+  desc "Get API total hits"
+  task :total_hits, [:app_id, :appsignal_token, :from, :to] => :environment do |t, args|
+    BASE_URL = "https://appsignal.com/api"
+    PARAMS = {
+      token: args[:appsignal_token],
+      from: args[:from],
+      to: args[:to],
+      kind: 'custom'
+    }
+
+    URL = "#{BASE_URL}/#{args[:app_id]}/graphs/custom.json?"
+
+    begin
+      uri = URI(URL)
+      uri.query = URI.encode_www_form(PARAMS)
+      puts("The following url has been produced:\n#{uri}")
+      res = Net::HTTP.get_response(uri)
+      json = JSON.parse(res.body)
+      total_hits = 0
+      json["data"].each do |data|
+        next unless data["data"]["c"]
+        total_hits += data["data"]["c"]["total_hits"].to_i
+      end
+      puts total_hits
+    rescue => e
+      puts e.message
+    end
+
+  end
+end


### PR DESCRIPTION
This rake tasks uses the AppSignal (hidden?) APIs to get the total number of hits on our PP API.
