### PR TITLE
Change returned fields

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,3 @@ DEPENDENCIES
   rake (~> 10.5.0)
   sinatra (~> 1.4.6)
   slack-notifier (~> 1.5.1)
-
-BUNDLED WITH
-   1.11.2

--- a/api/v3/views/country.rabl
+++ b/api/v3/views/country.rabl
@@ -43,10 +43,9 @@ end
 # Relations
 if @current_user.access_to?(Country, :country_statistic)
   child :country_statistic => :statistics do
-    attributes :pa_area, :percentage_cover_pas, :eez_area,
-      :ts_area, :pa_land_area, :pa_marine_area, :percentage_pa_land_cover,
-      :percentage_pa_eez_cover, :percentage_pa_ts_cover, :land_area, :percentage_pa_cover,
-      :pa_eez_area, :pa_ts_area, :percentage_pa_marine_cover, :marine_area,
+    attributes :pa_land_area, :pa_marine_area,
+      :land_area, :percentage_pa_cover,
+      :percentage_pa_marine_cover, :marine_area,
       :polygons_count, :points_count
   end
 end

--- a/api/v3/views/country.rabl
+++ b/api/v3/views/country.rabl
@@ -44,7 +44,7 @@ end
 if @current_user.access_to?(Country, :country_statistic)
   child :country_statistic => :statistics do
     attributes :pa_land_area, :pa_marine_area,
-      :land_area, :percentage_pa_cover,
+      :land_area, :percentage_pa_land_cover,
       :percentage_pa_marine_cover, :marine_area,
       :polygons_count, :points_count
   end

--- a/api/v3/views/country.rabl
+++ b/api/v3/views/country.rabl
@@ -53,8 +53,10 @@ end
 if @current_user.access_to?(Country, :pame_statistic)
   child :pame_statistic => :pame_statistics do
     attributes :assessments, :assessed_pas,
-      :average_score, :total_area_assessed,
-      :percentage_area_assessed
+      :pame_pa_land_area,
+      :pame_percentage_pa_land_cover,
+      :pame_pa_marine_area,
+      :pame_percentage_pa_marine_cover
   end
 end
 

--- a/web/views/documentation/countries.md
+++ b/web/views/documentation/countries.md
@@ -36,19 +36,10 @@ Sample response:
             "pas_regional_count": 0,
             "pas_international_count": 11,
             "statistics": {
-                "pa_area": 51844.34889409,
-                "percentage_cover_pas": null,
-                "eez_area": null,
-                "ts_area": 298762.86,
                 "pa_land_area": 32739.84,
                 "pa_marine_area": 19104.50889409,
                 "percentage_pa_land_cover": 10.96,
-                "percentage_pa_eez_cover": null,
-                "percentage_pa_ts_cover": null,
                 "land_area": 298762.86,
-                "percentage_pa_cover": 12,
-                "pa_eez_area": null,
-                "pa_ts_area": null,
                 "percentage_pa_marine_cover": 1.04,
                 "marine_area": 1829405.068391,
                 "polygons_count": 16,
@@ -57,9 +48,10 @@ Sample response:
             "pame_statistics": {
                 "assessments": 39,
                 "assessed_pas": 18,
-                "average_score": 0.496317020061398,
-                "total_area_assessed": 9884.5502680511,
-                "percentage_area_assessed": 13.1224063174949
+                "pame_pa_land_area": 5807.692147,
+                "pame_percentage_pa_land_cover": 1.943835,
+                "pame_pa_marine_area": 1523.50019,
+                "pame_percentage_pa_marine_cover": 0.083023
             },
             "region": {
                 "name": "Asia",
@@ -126,19 +118,10 @@ Sample response:
             "pas_regional_count": 0,
             "pas_international_count": 11,
             "statistics": {
-                "pa_area": 4104.71,
-                "percentage_cover_pas": null,
-                "eez_area": null,
-                "ts_area": 41355.27,
                 "pa_land_area": 4104.71,
                 "pa_marine_area": null,
                 "percentage_pa_land_cover": 9.93,
-                "percentage_pa_eez_cover": null,
-                "percentage_pa_ts_cover": null,
                 "land_area": 41355.27,
-                "percentage_pa_cover": 9.93,
-                "pa_eez_area": null,
-                "pa_ts_area": null,
                 "percentage_pa_marine_cover": null,
                 "marine_area": null,
                 "polygons_count": 0,
@@ -147,9 +130,10 @@ Sample response:
             "pame_statistics": {
                 "assessments": 20,
                 "assessed_pas": 14,
-                "average_score": 0.780597953216374,
-                "total_area_assessed": 1266.50166158781,
-                "percentage_area_assessed": 21.5681993197221
+                "pame_pa_land_area": 2610.795789,
+                "pame_percentage_pa_land_cover": 6.313091,
+                "pame_pa_marine_area": 0,
+                "pame_percentage_pa_marine_cover": 0
             },
             "region": {
                 "name": "Europe",
@@ -239,19 +223,10 @@ Sample response:
             }
         },
         "statistics": {
-            "pa_area": 2565883.979754,
-            "percentage_cover_pas": null,
-            "eez_area": null,
-            "ts_area": 9336666.44,
             "pa_land_area": 1294475.95,
             "pa_marine_area": 1271408.029754,
             "percentage_pa_land_cover": 13.86,
-            "percentage_pa_eez_cover": null,
-            "percentage_pa_ts_cover": null,
             "land_area": 9336666.44,
-            "percentage_pa_cover": 26.32,
-            "pa_eez_area": null,
-            "pa_ts_area": null,
             "percentage_pa_marine_cover": 12.46,
             "marine_area": 10201208.33913,
             "polygons_count": 1,
@@ -260,9 +235,10 @@ Sample response:
         "pame_statistics": {
             "assessments": 101,
             "assessed_pas": 79,
-            "average_score": 0.621947365828616,
-            "total_area_assessed": 517805.948887391,
-            "percentage_area_assessed": 18.834276817517
+            "pame_pa_land_area": 154799.8198,
+            "pame_percentage_pa_land_cover": 1.631122,
+            "pame_pa_marine_area": 1537642.023,
+            "pame_percentage_pa_marine_cover": 17.89726
         },
         "region": {
             "name": "North America",


### PR DESCRIPTION
## Description

* Remove unnecessary fields from country and PAME statistics
* Add land and marine related fields in PAME statistics
* Update documentation

Related [codebase ticket](https://unep-wcmc.codebasehq.com/projects/protected-planet-support-and-maintenance/tickets/99)
Related [PP PR](https://github.com/unepwcmc/ProtectedPlanet/pull/363) to populate the `assessments` and `assessed_pas` fields