### PR TITLE
feat(protected_areas): added attributes in database to the API. Fixed broken attributes

### DIFF
--- a/api/v3/views/protected_area.rabl
+++ b/api/v3/views/protected_area.rabl
@@ -41,6 +41,22 @@ if @current_user.access_to?(ProtectedArea, :is_green_list)
   attribute :is_green_list
 end
 
+if @current_user.access_to?(ProtectedArea, :is_oecm)
+  attribute :is_oecm
+end
+
+if @current_user.access_to?(ProtectedArea, :supplementary_info)
+  attribute :supplementary_info
+end
+
+if @current_user.access_to?(ProtectedArea, :conservation_objectives)
+  attribute :conservation_objectives
+end
+
+if @current_user.access_to?(ProtectedArea, :green_list_url)
+  attribute :green_list_url
+end
+
 # Relations
 if @current_user.access_to?(ProtectedArea, :countries)
   child :countries, object_root: false do
@@ -49,8 +65,8 @@ if @current_user.access_to?(ProtectedArea, :countries)
   end
 end
 
-if @current_user.access_to?(ProtectedArea, :sublocations)
-  child :sublocations, object_root: false do
+if @current_user.access_to?(ProtectedArea, :sub_locations)
+  child :sub_locations, object_root: false do
     attributes :id, :english_name
   end
 end
@@ -107,5 +123,11 @@ if @current_user.access_to?(ProtectedArea, :pame_evaluations)
       attributes :data_title, :resp_party,
       :year, :language
     end
+  end
+end
+
+if @current_user.access_to?(ProtectedArea, :green_list_status)
+  child :green_list_status, object_root: false do
+    attributes :id, :status, :expiry_date
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@ default: &default
   pool: 5
   timeout: 5000
   username: postgres
-  database: protectedplanet-development
+  database: pp_development
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@ default: &default
   pool: 5
   timeout: 5000
   username: postgres
-  database: pp_development
+  database: protectedplanet-development
 
 development:
   <<: *default

--- a/models/green_list_status.rb
+++ b/models/green_list_status.rb
@@ -1,0 +1,3 @@
+class GreenListStatus < ActiveRecord::Base
+  has_one :protected_area
+end

--- a/models/protected_area.rb
+++ b/models/protected_area.rb
@@ -15,7 +15,9 @@ class ProtectedArea < ActiveRecord::Base
     :legal_status, :legal_status_updated_at,
     :management_plan, :management_authority,
     :governance, :reported_area, :reported_marine_area,
-    :owner_type, :pame_evaluations
+    :owner_type, :pame_evaluations, :sub_locations,
+    :green_list_status, :is_oecm, :supplementary_info,
+    :conservation_objectives, :green_list_url
   ]
 
   belongs_to :iucn_category
@@ -24,6 +26,7 @@ class ProtectedArea < ActiveRecord::Base
   belongs_to :governance
   belongs_to :no_take_status
   belongs_to :management_authority
+  belongs_to :green_list_status
   has_and_belongs_to_many :countries, -> { select(:id, :name, :iso_3) }
   has_and_belongs_to_many :sub_locations
   has_many :pame_evaluations
@@ -55,5 +58,9 @@ class ProtectedArea < ActiveRecord::Base
 
   def link_to_pp
     File.join($secrets[:host], self.wdpa_id.to_s)
+  end
+
+  def is_green_list
+    green_list_status_id.present?
   end
 end

--- a/web/views/documentation/protected_areas.md
+++ b/web/views/documentation/protected_areas.md
@@ -71,6 +71,10 @@ Sample response:
             "reported_area": "0.3933",
             "management_plan": "Not Reported",
             "is_green_list": false,
+            "is_oecm": false,
+            "supplementary_info": "Not Applicable",
+            "conservation_objectives": "Not Applicable",
+            "green_list_url": null,
             "owner_type": "Not Reported",
             "countries": [
                 {
@@ -79,12 +83,13 @@ Sample response:
                     "id": "UGA"
                 }
             ],
+            "sub_locations": [],
             "iucn_category": {
                 "id": 8,
                 "name": "Not Reported"
             },
             "designation": {
-                "id": 12,
+                "id": 13,
                 "name": "Forest Reserve",
                 "jurisdiction": {
                     "id": 1,
@@ -92,7 +97,7 @@ Sample response:
                 }
             },
             "no_take_status": {
-                "id": 11851,
+                "id": 11293,
                 "name": "Not Applicable",
                 "area": "0.0"
             },
@@ -109,6 +114,7 @@ Sample response:
                 "governance_type": "Governance by Government"
             },
             "pame_evaluations": [],
+            "green_list_status": null,
             "links": {
                 "protected_planet": "http://protectedplanet.net/40366"
             },
@@ -265,6 +271,10 @@ Sample response:
             "reported_area": "484.6",
             "management_plan": "Not Reported",
             "is_green_list": false,
+            "is_oecm": false,
+            "supplementary_info": "Not Applicable",
+            "conservation_objectives": "Not Applicable",
+            "green_list_url": null,
             "owner_type": "Not Reported",
             "countries": [
                 {
@@ -273,6 +283,7 @@ Sample response:
                     "id": "MAR"
                 }
             ],
+            "sub_locations": [],
             "iucn_category": {
                 "id": 10,
                 "name": "Not Assigned"
@@ -286,12 +297,12 @@ Sample response:
                 }
             },
             "no_take_status": {
-                "id": 157133,
+                "id": 148453,
                 "name": "Not Reported",
                 "area": "0.0"
             },
             "legal_status": {
-                "id": 5,
+                "id": 6,
                 "name": "Adopted"
             },
             "management_authority": {
@@ -304,19 +315,20 @@ Sample response:
             },
             "pame_evaluations": [
                 {
-                    "id": 55317,
-                    "metadata_id": 42,
-                    "url": "Not Reported",
+                    "id": 29653,
+                    "metadata_id": 27,
+                    "url": "Not reported",
                     "year": 2018,
                     "methodology": "IMET",
                     "source": {
-                        "data_title": "List of protected areas assessed with the Integrated Management Effectiveness Tool (IMET)",
-                        "resp_party": "European Commission",
+                        "data_title": "JRC IMET information",
+                        "resp_party": "JRC",
                         "year": 2019,
                         "language": "English"
                     }
                 }
             ],
+            "green_list_status": null,
             "links": {
                 "protected_planet": "http://protectedplanet.net/555547509"
             },
@@ -391,6 +403,10 @@ Sample response:
         "reported_area": "0.3933",
         "management_plan": "Not Reported",
         "is_green_list": false,
+        "is_oecm": false,
+        "supplementary_info": "Not Applicable",
+        "conservation_objectives": "Not Applicable",
+        "green_list_url": null,
         "owner_type": "Not Reported",
         "countries": [
             {
@@ -399,12 +415,13 @@ Sample response:
                 "id": "UGA"
             }
         ],
+        "sub_locations": [],
         "iucn_category": {
             "id": 8,
             "name": "Not Reported"
         },
         "designation": {
-            "id": 12,
+            "id": 13,
             "name": "Forest Reserve",
             "jurisdiction": {
                 "id": 1,
@@ -412,7 +429,7 @@ Sample response:
             }
         },
         "no_take_status": {
-            "id": 11851,
+            "id": 11293,
             "name": "Not Applicable",
             "area": "0.0"
         },
@@ -429,6 +446,7 @@ Sample response:
             "governance_type": "Governance by Government"
         },
         "pame_evaluations": [],
+        "green_list_status": null,
         "links": {
             "protected_planet": "http://protectedplanet.net/40366"
         },


### PR DESCRIPTION
Adds some extra fields to the API response, updates the documentation, and fixes some non-working attributes.

To test:

set up this app, making sure db is pointed at your protected planet database
run ```rake api_users:reset_permissions```
make API calls to /v3/protected_areas and /v3/protected_areas/:id
api response should include :green_list_status,  :is_oecm, :supplementary_info, :conservation_objectives, :green_list_url, :green_list_status, and :sub_locations should display correctly
