### PR TITLE
fix: add OECM data to statistics key

### DIFF
--- a/api/v3/views/country.rabl
+++ b/api/v3/views/country.rabl
@@ -46,7 +46,8 @@ if @current_user.access_to?(Country, :country_statistic)
     attributes :pa_land_area, :pa_marine_area,
       :land_area, :percentage_pa_land_cover,
       :percentage_pa_marine_cover, :marine_area,
-      :polygons_count, :points_count
+      :polygons_count, :points_count, :percentage_oecms_pa_marine_cover,
+      :oecms_pa_land_area, :oecms_pa_marine_area, :percentage_oecms_pa_land_cover
   end
 end
 

--- a/web/views/documentation/countries.md
+++ b/web/views/documentation/countries.md
@@ -43,7 +43,11 @@ Sample response:
                 "percentage_pa_marine_cover": 1.04,
                 "marine_area": 1829405.068391,
                 "polygons_count": 16,
-                "points_count": 16
+                "points_count": 16,
+                "percentage_oecms_pa_marine_cover": 3.628933257,
+                "oecms_pa_land_area": 51650.29769,
+                "oecms_pa_marine_area": 66591.94832,
+                "percentage_oecms_pa_land_cover": 17.28736145
             },
             "pame_statistics": {
                 "assessments": 39,


### PR DESCRIPTION
I have added those 4 attributes:
`oecms_pa_land_area`
`oecms_pa_marine_area`
`percentage_oecms_pa_land_cover`
`percentage_oecms_pa_marine_cover`
