### PR TITLE
Feat/93/add geom count fields to api

### DIFF
--- a/api/v3/views/country.rabl
+++ b/api/v3/views/country.rabl
@@ -48,7 +48,9 @@ if @current_user.access_to?(Country, :country_statistic)
       :percentage_pa_marine_cover, :marine_area,
       :polygons_count, :points_count,
       :percentage_oecms_pa_marine_cover, :oecms_pa_land_area,
-      :oecms_pa_marine_area, :percentage_oecms_pa_land_cover
+      :oecms_pa_marine_area, :percentage_oecms_pa_land_cover,
+      :oecm_polygon_count, :oecm_point_count,
+      :protected_area_polygon_count, :protected_area_point_count
   end
 end
 

--- a/api/v3/views/country.rabl
+++ b/api/v3/views/country.rabl
@@ -47,10 +47,10 @@ if @current_user.access_to?(Country, :country_statistic)
       :land_area, :percentage_pa_land_cover,
       :percentage_pa_marine_cover, :marine_area,
       :polygons_count, :points_count,
-      :percentage_oecms_pa_marine_cover, :oecms_pa_land_area,
-      :oecms_pa_marine_area, :percentage_oecms_pa_land_cover,
       :oecm_polygon_count, :oecm_point_count,
-      :protected_area_polygon_count, :protected_area_point_count
+      :protected_area_polygon_count, :protected_area_point_count,
+      :percentage_oecms_pa_marine_cover, :oecms_pa_land_area,
+      :oecms_pa_marine_area, :percentage_oecms_pa_land_cover
   end
 end
 

--- a/web/views/documentation/countries.md
+++ b/web/views/documentation/countries.md
@@ -44,6 +44,10 @@ Sample response:
                 "marine_area": 1829405.068391,
                 "polygons_count": 16,
                 "points_count": 16,
+                "oecm_polygon_count": 42,
+                "oecm_point_count": 136,
+                "protected_area_polygon_count": 265,
+                "protected_area_point_count": 8,
                 "percentage_oecms_pa_marine_cover": 3.628933257,
                 "oecms_pa_land_area": 51650.29769,
                 "oecms_pa_marine_area": 66591.94832,
@@ -130,6 +134,10 @@ Sample response:
                 "marine_area": null,
                 "polygons_count": 0,
                 "points_count": 2
+                "oecm_polygon_count": 0,
+                "oecm_point_count": 0,
+                "protected_area_polygon_count": 10772,
+                "protected_area_point_count": 2
             },
             "pame_statistics": {
                 "assessments": 20,
@@ -235,6 +243,10 @@ Sample response:
             "marine_area": 10201208.33913,
             "polygons_count": 1,
             "points_count": 37,
+            "oecm_polygon_count": 0,
+            "oecm_point_count": 0,
+            "protected_area_polygon_count": 42770,
+            "protected_area_point_count": 56,
             "percentage_oecms_pa_marine_cover": 3.628933257,
             "oecms_pa_land_area": 51650.29769,
             "oecms_pa_marine_area": 66591.94832,


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/data-infrastructure-refactor/tickets/93

Add the new geom count fields to the api response and documentation.

Testing:

start app ```rackup```
get an api token from the database:
```
RAILS_ENV=development bundle exec irb
$LOAD_PATH.unshift("#{File.dirname(__FILE__)}"); require 'config/environment.rb'; require 'lib/mailer.rb'
ApiUser.last.token
```

query the endpoints:
```
http://localhost:9292/v3/countries?token={{token}}
http://localhost:9292/v3/countries/ZWE?token={{token}}
````
New fields should appear in the statistics section (:oecm_polygon_count, :oecm_point_count, :protected_area_polygon_count, :protected_area_point_count)

Check documentation at ```http://localhost:9292/documentation```

